### PR TITLE
Fix Actions Volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN docker-php-ext-install \
     soap
 
 # install pecl
-RUN pecl install mongodb-1.9.0
+RUN pecl install mongodb-1.12.0
 
 RUN docker-php-ext-enable \
     mongodb
@@ -49,7 +49,7 @@ RUN chmod +x /usr/bin/composer
 
 # install worker
 COPY . /var/www/html/worker
-RUN cd /var/www/html/worker && /usr/bin/composer install && mkdir /var/www/html/worker/src/actions
+RUN cd /var/www/html/worker && /usr/bin/composer install && mkdir /var/www/html/worker/actions
 RUN chown -R www-data: /var/www/html/worker
 
 # apache config
@@ -57,6 +57,6 @@ RUN sed -i 's/80/9092/g' /etc/apache2/ports.conf /etc/apache2/sites-available/00
 RUN sed -i 's!/var/www/html!/var/www/html/worker/public!g' /etc/apache2/sites-available/*.conf
 RUN sed -i 's!/var/www/!/var/www/html/worker/public!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
-VOLUME /var/www/html/worker/src/actions
+VOLUME /var/www/html/worker/actions
 
 EXPOSE 9092

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN chmod +x /usr/bin/composer
 
 # install worker
 COPY . /var/www/html/worker
-RUN cd /var/www/html/worker && /usr/bin/composer install
+RUN cd /var/www/html/worker && /usr/bin/composer install && mkdir /var/www/html/worker/src/actions
 RUN chown -R www-data: /var/www/html/worker
 
 # apache config
@@ -57,6 +57,6 @@ RUN sed -i 's/80/9092/g' /etc/apache2/ports.conf /etc/apache2/sites-available/00
 RUN sed -i 's!/var/www/html!/var/www/html/worker/public!g' /etc/apache2/sites-available/*.conf
 RUN sed -i 's!/var/www/!/var/www/html/worker/public!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
-VOLUME /worker/actions
+VOLUME /var/www/html/worker/src/actions
 
 EXPOSE 9092

--- a/src/WorkerHandler.php
+++ b/src/WorkerHandler.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 
 class WorkerHandler implements WorkerIf
 {
-    private const ACTIONS_DIR = './actions';
+    private const ACTIONS_DIR = __DIR__.'./actions';
     private ?\stdClass $connections = null;
     private array $actions = [];
     private LoggerInterface $logger;

--- a/src/WorkerHandler.php
+++ b/src/WorkerHandler.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 
 class WorkerHandler implements WorkerIf
 {
-    private const ACTIONS_DIR = __DIR__.'./actions';
+    private const ACTIONS_DIR = __DIR__.'/../actions';
     private ?\stdClass $connections = null;
     private array $actions = [];
     private LoggerInterface $logger;


### PR DESCRIPTION
In Dockerfile we use volume '/worker/actions' to save actions and connections, but in source code (WorkerHandler.php) it is use './actions' as directory for actions and connections.  '/actions' in file WorkerHandler.php means '/var/www/html/worker/public/actions'. I think there is inconsistent in here. 

I propose to change the path to '/var/www/html/worker/src/actions' both in Dockerfile and source code.