### PR TITLE
Add Oracle instantclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.1-apache
 ENV COMPOSER_VERSION "2.1.9"
 ENV COMPOSER_SHA256 "4d00b70e146c17d663ad2f9a21ebb4c9d52b021b1ac15f648b4d371c04d648ba"
 
@@ -16,7 +16,8 @@ RUN apt-get update && apt-get -y install \
     libpng-dev \
     openssl \
     libssl-dev \
-    libcurl4-openssl-dev
+    libcurl4-openssl-dev \
+    libaio1
 
 # install php extensions
 RUN docker-php-ext-install \
@@ -37,10 +38,35 @@ RUN docker-php-ext-install \
     soap
 
 # install pecl
-RUN pecl install mongodb-1.9.0
+RUN pecl install mongodb-1.12.0
 
 RUN docker-php-ext-enable \
     mongodb
+
+# Install Oracle Instantclient
+RUN mkdir /opt/oracle \
+    && cd /opt/oracle \
+    && wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip \
+    && wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip \
+    && unzip /opt/oracle/instantclient-basic-linuxx64.zip -d /opt/oracle \
+    && unzip /opt/oracle/instantclient-sdk-linuxx64.zip -d /opt/oracle \
+    && rm -rf /opt/oracle/*.zip \
+    && DIR_ORACLE_INSTANT_CLIENT=$(ls -d /opt/oracle/*/ | sed 's:/$::g') \
+    && echo $DIR_ORACLE_INSTANT_CLIENT > /etc/ld.so.conf.d/oracle-instantclient.conf \
+    && ldconfig
+
+# Install Oracle extensions
+RUN DIR_ORACLE_INSTANT_CLIENT=$(ls -d /opt/oracle/*/ | sed 's:/$::g') \
+    && VER_MAY_ORACLE_INSTANT_CLIENT=$(echo $DIR_ORACLE_INSTANT_CLIENT | cut -d "_" -f 2) \
+    && VER_MIN_ORACLE_INSTANT_CLIENT=$(echo $DIR_ORACLE_INSTANT_CLIENT | cut -d "_" -f 3) \
+    && echo "instantclient,$DIR_ORACLE_INSTANT_CLIENT" | pecl install oci8 \
+    && docker-php-ext-enable \
+           oci8
+RUN DIR_ORACLE_INSTANT_CLIENT=$(ls -d /opt/oracle/*/ | sed 's:/$::g') \
+    && VER_MAY_ORACLE_INSTANT_CLIENT=$(echo $DIR_ORACLE_INSTANT_CLIENT | cut -d "_" -f 2) \
+    && VER_MIN_ORACLE_INSTANT_CLIENT=$(echo $DIR_ORACLE_INSTANT_CLIENT | cut -d "_" -f 3) \
+    && docker-php-ext-configure pdo_oci --with-pdo-oci=instantclient,$DIR_ORACLE_INSTANT_CLIENT,${VER_MAY_ORACLE_INSTANT_CLIENT}.${VER_MIN_ORACLE_INSTANT_CLIENT} \
+    && docker-php-ext-install pdo_oci
 
 # install composer
 RUN wget -O /usr/bin/composer https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar


### PR DESCRIPTION
I propose to add Oracle Instantclient so oci8 and pdo_oci can be installed. As consequence, PHP is upgrade to 8.1, and also mongo is upgrade to 1.12.0.